### PR TITLE
Gets the correct tweet id.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -5,6 +5,9 @@
 
 `npm install monitor-twitter`
 
+Note: this gets the id_str not the id. id_str is what's used to identify tweets. See this: 
+https://dev.twitter.com/overview/api/twitter-ids-json-and-snowflake
+
 
 ## Example
 

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function Monitor(config) {
 
   this.stripData = function stripData(data) {
     return _.map(data, function(d) {
-        return {text: d.text, id: d.id};
+        return {text: d.text, id: d.id_str};
       });
   };
 


### PR DESCRIPTION
Since tweet.id no longer works, it gets the correct identifier: id_str

